### PR TITLE
[ready] Improve setting to support float and big decimal

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
       zeitwerk (~> 2.1, >= 2.1.4)
     ast (2.4.0)
     builder (3.2.3)
+    byebug (11.1.1)
     codecov (0.1.9)
       json
       simplecov
@@ -168,6 +169,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  byebug
   codecov
   minitest
   rails (= 6.0.0.rc1)
@@ -177,4 +179,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -332,3 +332,10 @@ Same values will fetch from the `settings` table.
 - [tootsuite/mastodon](https://github.com/tootsuite/mastodon)
 - [helpyio/helpy](https://github.com/helpyio/helpy)
 
+
+## Run minitest:
+
+```cmd
+bundle
+rake test
+```

--- a/lib/rails-settings/base.rb
+++ b/lib/rails-settings/base.rb
@@ -9,8 +9,6 @@ module RailsSettings
     SEPARATOR_REGEXP = /[\n,;]+/
     self.table_name = table_name_prefix + "settings"
 
-    @@setting_names = []
-
     # get the value field, YAML decoded
     def value
       YAML.load(self[:value]) if self[:value].present?
@@ -32,7 +30,8 @@ module RailsSettings
       end
 
       def field(key, **opts)
-        @@setting_names << key.to_s
+        @keys ||= []
+        @keys << key.to_s
         _define_field(key, default: opts[:default], type: opts[:type], readonly: opts[:readonly], separator: opts[:separator])
       end
 
@@ -46,8 +45,8 @@ module RailsSettings
         scope.join("/")
       end
 
-      def setting_names
-        @@setting_names
+      def keys
+        @keys
       end
 
       private

--- a/rails-settings-cached.gemspec
+++ b/rails-settings-cached.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "simplecov"
   s.add_development_dependency "minitest"
   s.add_development_dependency "codecov"
+  s.add_development_dependency "byebug"
 end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -35,6 +35,14 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal({}, Setting.send(:_all_settings))
   end
 
+  test "setting_keys" do
+    assert_equal 11, Setting.setting_names.size
+    assert_includes(Setting.setting_names, "host")
+    assert_includes(Setting.setting_names, "readonly_item")
+    assert_includes(Setting.setting_names, "default_tags")
+    assert_includes(Setting.setting_names, "omniauth_google_options")
+  end
+
   test "not exist field" do
     assert_raise(NoMethodError) { Setting.not_exist_method  }
   end
@@ -65,16 +73,89 @@ class BaseTest < ActiveSupport::TestCase
 
   test "integer field" do
     assert_equal 1, Setting.user_limits
+    assert_instance_of Integer, Setting.user_limits
+    assert_no_record :user_limits
+
     Setting.user_limits = 12
     assert_equal 12, Setting.user_limits
+    assert_instance_of Integer, Setting.user_limits
     assert_record_value :user_limits, 12
+
+    Setting.user_limits = "27"
+    assert_equal 27, Setting.user_limits
+    assert_instance_of Integer, Setting.user_limits
+    assert_record_value :user_limits, 27
+
+    Setting.user_limits = 2.7
+    assert_equal 2, Setting.user_limits
+    assert_instance_of Integer, Setting.user_limits
+    assert_record_value :user_limits, 2
+  end
+
+  test "float field" do
+    assert_equal 7, Setting.float_item
+    assert_instance_of Float, Setting.float_item
+    assert_no_record :float_item
+
+    Setting.float_item = 9
+    assert_equal 9, Setting.float_item
+    assert_instance_of Float, Setting.float_item
+    assert_record_value :float_item, 9.to_f
+
+    Setting.float_item = 2.9
+    assert_equal 2.9, Setting.float_item
+    assert_instance_of Float, Setting.float_item
+    assert_record_value :float_item, 2.9
+
+    Setting.float_item = "2.9"
+    assert_equal 2.9, Setting.float_item
+    assert_instance_of Float, Setting.float_item
+    assert_record_value :float_item, "2.9".to_f
+  end
+
+  test "big decimal field" do
+    assert_equal 9, Setting.big_decimal_item
+    assert_instance_of BigDecimal, Setting.big_decimal_item
+    assert_no_record :big_decimal_item
+
+    Setting.big_decimal_item = 7
+    assert_equal 7, Setting.big_decimal_item
+    assert_instance_of BigDecimal, Setting.big_decimal_item
+    assert_record_value :big_decimal_item, 7.to_d
+
+    Setting.big_decimal_item = 2.9
+    assert_equal 2.9, Setting.big_decimal_item
+    assert_instance_of BigDecimal, Setting.big_decimal_item
+    assert_record_value :big_decimal_item, 2.9.to_d
+
+    Setting.big_decimal_item = "2.9"
+    assert_equal 2.9, Setting.big_decimal_item
+    assert_instance_of BigDecimal, Setting.big_decimal_item
+    assert_record_value :big_decimal_item, "2.9".to_d
   end
 
   test "array field" do
     assert_equal %w[admin@rubyonrails.org], Setting.admin_emails
     assert_no_record :admin_emails
+
     new_emails = %w[admin@rubyonrails.org huacnlee@gmail.com]
+    Setting.admin_emails = new_emails
+    assert_equal new_emails, Setting.admin_emails
+    assert_record_value :admin_emails, new_emails
+
     Setting.admin_emails = new_emails.join("\n")
+    assert_equal new_emails, Setting.admin_emails
+    assert_record_value :admin_emails, new_emails
+
+    Setting.admin_emails = new_emails.join(",")
+    assert_equal new_emails, Setting.admin_emails
+    assert_record_value :admin_emails, new_emails
+
+    Setting.admin_emails = new_emails.join(";")
+    assert_equal new_emails, Setting.admin_emails
+    assert_record_value :admin_emails, new_emails
+
+    Setting.admin_emails = new_emails.join(" , ")
     assert_equal new_emails, Setting.admin_emails
     assert_record_value :admin_emails, new_emails
   end
@@ -112,6 +193,32 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal 32, Setting.smtp_settings["age"]
     assert_equal "Jason Lee", Setting.smtp_settings[:name]
     assert_equal "Jason Lee", Setting.smtp_settings["name"]
+    assert_record_value :smtp_settings, new_value
+
+    new_value = {
+      "sym" => :symbol,
+      "str" => "string",
+      "num" => 27.72
+    }
+    Setting.smtp_settings = new_value
+    assert_equal new_value.deep_stringify_keys, Setting.smtp_settings
+    assert_equal :symbol, Setting.smtp_settings[:sym]
+    assert_equal "string", Setting.smtp_settings["str"]
+    assert_equal 27.72, Setting.smtp_settings["num"]
+    assert_record_value :smtp_settings, new_value
+
+    Setting.smtp_settings = new_value.to_s
+    assert_equal new_value.deep_stringify_keys, Setting.smtp_settings
+    assert_equal :symbol, Setting.smtp_settings[:sym]
+    assert_equal "string", Setting.smtp_settings["str"]
+    assert_equal 27.72, Setting.smtp_settings["num"]
+    assert_record_value :smtp_settings, new_value
+
+    Setting.smtp_settings = new_value.to_yaml
+    assert_equal new_value.deep_stringify_keys, Setting.smtp_settings
+    assert_equal :symbol, Setting.smtp_settings[:sym]
+    assert_equal "string", Setting.smtp_settings["str"]
+    assert_equal 27.72, Setting.smtp_settings["num"]
     assert_record_value :smtp_settings, new_value
   end
 

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -36,11 +36,11 @@ class BaseTest < ActiveSupport::TestCase
   end
 
   test "setting_keys" do
-    assert_equal 11, Setting.setting_names.size
-    assert_includes(Setting.setting_names, "host")
-    assert_includes(Setting.setting_names, "readonly_item")
-    assert_includes(Setting.setting_names, "default_tags")
-    assert_includes(Setting.setting_names, "omniauth_google_options")
+    assert_equal 11, Setting.keys.size
+    assert_includes(Setting.keys, "host")
+    assert_includes(Setting.keys, "readonly_item")
+    assert_includes(Setting.keys, "default_tags")
+    assert_includes(Setting.keys, "omniauth_google_options")
   end
 
   test "not exist field" do

--- a/test/models/setting.rb
+++ b/test/models/setting.rb
@@ -19,4 +19,6 @@ class Setting < RailsSettings::Base
     client_id: "the-client-id",
     client_secret: "the-client-secret",
   }, type: :string, readonly: true
+  field :float_item, type: :float, default: 7
+  field :big_decimal_item, type: :big_decimal, default: 9
 end


### PR DESCRIPTION
task: [Improve for settings](https://app.vivifyscrum.com/boards/84924/sprint-backlog/277295/DANX-485)

we fork & update this gem to support setting with float & big decimal types, also expand the support with array & hash types

đang thử tạo PR cho repo chính và pass test 😄 https://github.com/huacnlee/rails-settings-cached/pull/180/commits